### PR TITLE
ci: only run npm publish on release publish

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,10 +1,14 @@
 name: NPM Publish
 permissions: read-all
-on: release
+on:
+  release:
+    types: [published]
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
     name: Publish Package
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Summary
Update the NPM Publish action in the following ways:
- Only run on release publish
- Give write permission for `id-token`