### PR TITLE
docs: update readme badges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release App
+name: Release
 permissions: read-all
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # library-galaxy-map
 
 <p align="center">
-  <!-- <a href="https://github.com/outoforbitdev/library-galaxy-map/actions?query=workflow%3ATest+branch%3Amaster">
-    <img alt="Build states" src="https://github.com/outoforbitdev/library-galaxy-map/workflows/Test/badge.svg">
-  </a> -->
-  <a href="https://github.com/outoforbitdev/library-galaxy-map/actions">
-    <img alt="Build states" src="https://github.com/outoforbitdev/library-galaxy-map/workflows/Release/badge.svg">
+  <a href="https://github.com/outoforbitdev/library-galaxy-map/actions?query=workflow%3ATest+branch%3Amaster">
+    <img alt="Test build states" src="https://github.com/outoforbitdev/library-galaxy-map/workflows/Test/badge.svg">
+  </a>
+  <a href="https://github.com/outoforbitdev/library-galaxy-map/actions?query=workflow%3ATest+branch%3Amaster">
+    <img alt="Release build states" src="https://github.com/outoforbitdev/library-galaxy-map/workflows/Release/badge.svg">
   </a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/outoforbitdev/library-galaxy-map">
     <img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/outoforbitdev/library-galaxy-map/badge">
   </a>
   <a href="https://github.com/outoforbitdev/library-galaxy-map/releases/latest">
-    <img alt="Latest release" src="https://img.shields.io/github/v/release/outoforbitdev/library-galaxy-map?logo=github">
+    <img alt="Latest github release" src="https://img.shields.io/github/v/release/outoforbitdev/library-galaxy-map?logo=github">
+  </a>
+  <a href ="">
+    <img alt="NPM Version" src="https://img.shields.io/npm/v/%40outoforbitdev%2Fgalaxy-map" />
   </a>
   <a href="https://github.com/outoforbitdev/library-galaxy-map/issues">
     <img alt="Open issues" src="https://img.shields.io/github/issues/outoforbitdev/library-galaxy-map?logo=github">


### PR DESCRIPTION
### Summary

Update README badges.
- Fix the badge for the Release action
- Add a badge for the Test action
- Add a badge for the npm package