### PR TITLE
chore: downgrade CHANGELOG and package.json to 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 0.0.2 (2025-02-02)
-
-### Features
-
-- switch to using npm instead of yarn for package management
-
 ## 0.0.1 (2025-02-02)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outoforbitdev/galaxy-map",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "An SVG galaxy map for React that displays planets and spacelanes in a coordinate system",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Downgrade version info to `0.0.1`. We've removed those tags and releases so that we can release fresh.