### PR TITLE
ci: npm run build before npm publish

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - run: npm run build
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.2 (2025-02-07)
+
+### Bug Fixes
+
+- include relevant files in npm release
+
 ## 0.0.1 (2025-02-02)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outoforbitdev/galaxy-map",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An SVG galaxy map for React that displays planets and spacelanes in a coordinate system",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Fix an issue where we weren't correctly building the package before publishing it.