### PR TITLE
ci: fix permissions for scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,5 +20,10 @@ permissions: read-all
 jobs:
   scorecard:
     uses: outoforbitdev/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
     secrets:
       scorecard_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix the permissions for the `GITHUB_TOKEN` for the scorecard workflow.