### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,17 @@
       "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
-        "client-app": "file:../app-galaxy-map/src/client",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",
         "@commitlint/config-conventional": "^19.7.1",
         "@rollup/plugin-commonjs": "^28.0.2",
-        "@rollup/plugin-node-resolve": "^15.3.1",
+        "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
-        "@types/react": "^18.3.18",
+        "@types/react": "^19.0.10",
         "commitlint": "^19.7.1",
         "husky": "^9.1.7",
         "postcss": "^8.5.1",
@@ -29,18 +28,19 @@
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-sourcemaps2": "^0.4.3",
+        "rollup-plugin-sourcemaps2": "^0.5.0",
         "tslib": "^2.8.1",
         "typescript": "^5.7.3"
       },
       "peerDependencies": {
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "../app-galaxy-map/src/client": {
       "name": "client-app",
       "version": "0.1.0",
+      "extraneous": true,
       "dependencies": {
         "@outoforbitdev/galaxy-map": "file:../../../library-galaxy-map/outoforbitdev-galaxy-map-0.0.6.tgz",
         "next": "15.1.6",
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz",
+      "integrity": "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -882,21 +882,13 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "version": "19.0.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
+      "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -1158,10 +1150,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/client-app": {
-      "resolved": "../app-galaxy-map/src/client",
-      "link": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2233,6 +2221,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2417,18 +2406,6 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
@@ -3475,28 +3452,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -3778,13 +3751,13 @@
       }
     },
     "node_modules/rollup-plugin-sourcemaps2": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps2/-/rollup-plugin-sourcemaps2-0.4.3.tgz",
-      "integrity": "sha512-q+50FHvE0RJVlSlQ2xf5AVuJHMnohSfev0j0VARr3gZSvAgh+s27cGz+w/yt3z8DpYnQVx9LKo2FFsEJ0uECkw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps2/-/rollup-plugin-sourcemaps2-0.5.0.tgz",
+      "integrity": "sha512-ozRq2fRuJYkA2cRT1CxaWNovtdBbrlXMK/vKIm5Q7rLUHx4jF21jZu1plO+VNOWPDAn+q1CaIAWKQL5QGej6Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "5.1.3"
+        "@rollup/pluginutils": "5.1.4"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3795,29 +3768,6 @@
       },
       "peerDependenciesMeta": {
         "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rollup-plugin-sourcemaps2/node_modules/@rollup/pluginutils": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
-      "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
           "optional": true
         }
       }
@@ -3892,13 +3842,10 @@
       "license": "ISC"
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.1",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "@commitlint/cli": "^19.7.1",
     "@commitlint/config-conventional": "^19.7.1",
     "@rollup/plugin-commonjs": "^28.0.2",
-    "@rollup/plugin-node-resolve": "^15.3.1",
+    "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.2",
-    "@types/react": "^18.3.18",
+    "@types/react": "^19.0.10",
     "commitlint": "^19.7.1",
     "husky": "^9.1.7",
     "postcss": "^8.5.1",
@@ -24,7 +24,7 @@
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-sourcemaps2": "^0.4.3",
+    "rollup-plugin-sourcemaps2": "^0.5.0",
     "tslib": "^2.8.1",
     "typescript": "^5.7.3"
   },
@@ -45,11 +45,11 @@
   "homepage": "https://github.com/outoforbitdev/library-galaxy-map#readme",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/src/components/GalaxyMap.tsx
+++ b/src/components/GalaxyMap.tsx
@@ -23,7 +23,7 @@ export interface IMapProps {
 }
 
 export default function Map(props: IMapProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [hidePlanetLabels, setHidePlanetLabels] = useState(
     props.mapOptions?.hidePlanetLabels ?? false,
   );

--- a/src/components/Zoomable.tsx
+++ b/src/components/Zoomable.tsx
@@ -9,7 +9,7 @@ import {
 import { getDomProps, IComponentProps } from "../oodreact/IComponent";
 
 export interface IZoomableProps extends IComponentProps {
-  containerRef: RefObject<HTMLDivElement>;
+  containerRef: RefObject<HTMLDivElement | null>;
   dimensions: {
     minX: number;
     minY: number;

--- a/src/components/ZoomableMap.tsx
+++ b/src/components/ZoomableMap.tsx
@@ -10,7 +10,7 @@ import { getDomProps } from "../oodreact/IComponent";
 export interface IZoomableMapProps {
   planets: IPlanet[];
   spacelanes: ISpacelane[];
-  containerRef: RefObject<HTMLDivElement>;
+  containerRef: RefObject<HTMLDivElement | null>;
   dimensions: {
     minX: number;
     minY: number;

--- a/src/oodreact/Draggable.tsx
+++ b/src/oodreact/Draggable.tsx
@@ -22,8 +22,8 @@ export interface IPosition {
 const defaultPosition: IPosition = { x: 0, y: 0 };
 
 export function Draggable(props: IDraggableProps) {
-  const draggableRef = useRef<HTMLDivElement>(null);
-  const staticRef = useRef<HTMLDivElement>(null);
+  const draggableRef = useRef<HTMLDivElement | null>(null);
+  const staticRef = useRef<HTMLDivElement | null>(null);
   const [position, setPosition] = useState(props.initialPosition);
   const [relativePosition, setRelativePosition] = useState(defaultPosition);
   const [isDragging, setIsDragging] = useState(false);
@@ -119,6 +119,6 @@ function diffPositions(first: IPosition, second: IPosition) {
   };
 }
 
-function getPositionFromRef(ref: RefObject<HTMLDivElement>) {
+function getPositionFromRef(ref: RefObject<HTMLDivElement | null>) {
   return ref.current ? ref.current.getBoundingClientRect() : defaultPosition;
 }


### PR DESCRIPTION
## Summary

This pull request upgrades the following dependencies:
- `@rollup/plugin-node-resolve` from `15.3.1` to `16.0.1`
- `rollup-plugin-sourcemaps2` from `0.4.4` to `0.5.0`
- `@types/react` from `18.3.18` to `19.0.10`
- `react` from `18.3.1` to `19.0.0`

Additionally, resolve some errors from the build step by changing `RefObject<HTMLDivElement>` type definitions to `RefObject<HTMLDivElement | null>`

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

Ran `just pack` and tested with production data set. Additionally fully built and packed the package and ran a full npm build of `app-galaxy-map`.

## Issues

- Closes #23
- Closes #34
- Closes #35
- Closes #51
