### PR TITLE
feat: allow adding generic react components to the options window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Next
+
+### Breaking Changes
+
+- This update includes a major change in the way that the Map Options window functions.
+  - The default options (`hidePlanetLabels`, `showPlanets`, and `showSpacelanes`) have been renamed to `planetLabelVisibility`, `planetVisibility`, and `spacelaneVisbility`, and accept any of the following strings: `show`, `dynamic` (default), or `hide`.
+    - Note that the `planetLabelVisibility` may not exceed the the `planetVisibility`. For example, if `planetVisibility` is `dynamic` and `planetLabelVisibility` is `show`, then `planetLabelVisibility` will be ignored.
+    - These options are now rendered as dropdown menus in the options window instead of boolean checkboxes.
+  - Instead of providing complex objects for `customOptions`, consumers now provide a `ReactNode`. This allows for full components of any type to be added to the options window, greatly expanding the options for consumers.
+
 ## 0.0.7 (2025-03-20)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -103,18 +103,18 @@ return (
 
 ### Component Props
 
-| Prop              | Type            | Default  | Description                                   |
-| ----------------- | --------------- | -------- | --------------------------------------------- |
-| `planets`         | `IPlanet[]`     | Required | List of planets to display on the map         |
-| `spacelanes`      | `ISpacelane[]`  | Required | List of spacelanes to display on the map      |
-| `dimensions.minX` | `number`        | Required | Minimum x coordinate that should be displayed |
-| `dimensions.minY` | `number`        | Required | Minimum y coordinate that should be displayed |
-| `dimensions.maxX` | `number`        | Required | Maximum x coordinate that should be displayed |
-| `dimensions.maxY` | `number`        | Required | Maximum y coordinate that should be displayed |
-| `mapOptions`      | `IMapOptions[]` | `[]`     | Options for the options window in the map     |
-| `zoom.initial`    | `number`        | `1`      | Initial zoom level for the map                |
-| `zoom.min`        | `number`        |          | Minimum zoom level                            |
-| `zoom.max`        | `number`        |          | Maximum zoom level                            |
+| Prop              | Type           | Default     | Description                                   |
+| ----------------- | -------------- | ----------- | --------------------------------------------- |
+| `planets`         | `IPlanet[]`    | Required    | List of planets to display on the map         |
+| `spacelanes`      | `ISpacelane[]` | Required    | List of spacelanes to display on the map      |
+| `dimensions.minX` | `number`       | Required    | Minimum x coordinate that should be displayed |
+| `dimensions.minY` | `number`       | Required    | Minimum y coordinate that should be displayed |
+| `dimensions.maxX` | `number`       | Required    | Maximum x coordinate that should be displayed |
+| `dimensions.maxY` | `number`       | Required    | Maximum y coordinate that should be displayed |
+| `mapOptions`      | `IMapOptions`  | `undefined` | Options for the options window in the map     |
+| `zoom.initial`    | `number`       | `1`         | Initial zoom level for the map                |
+| `zoom.min`        | `number`       |             | Minimum zoom level                            |
+| `zoom.max`        | `number`       |             | Maximum zoom level                            |
 
 ### IPlanet Props
 
@@ -138,20 +138,11 @@ return (
 | `color`      | `MapColor`   | Required | Color of the spacelane                             |
 | `focusLevel` | `FocusLevel` | Required | Zoom level at which the spacelane comes into focus |
 
-### IMapOptionsProps
+### IMapOptions
 
-| Prop                | Type          | Default | Description                                           |
-| ------------------- | ------------- | ------- | ----------------------------------------------------- |
-| `hidePlanetLabels`  | `boolean`     | `false` | Whether to hide planet text labels at all zoom levels |
-| `showAllPlanets`    | `boolean`     | `false` | Whether to show all planets at all zoom levels        |
-| `showAllSpacelanes` | `boolean`     | `false` | Whether to show all spacelanes at all zoom levels     |
-| `customOptions`     | `MapOption[]` | `[]`    | Additional options to show in the options window      |
-
-### MapOption Props
-
-| Prop           | Type                | Default  | Description                                      |
-| -------------- | ------------------- | -------- | ------------------------------------------------ |
-| `currentValue` | `boolean`           | Required | Current value of the option                      |
-| `setValue`     | `(boolean) => void` | Required | Callback when the value of the option is changed |
-| `label`        | `string`            | Required | Text label for the option                        |
-| `inputType`    | `string`            | Required | Input type for the input element of the option   |
+| Prop                    | Type                        | Default     | Description                                           |
+| ----------------------- | --------------------------- | ----------- | ----------------------------------------------------- |
+| `planetLabelVisibility` | `"dynamic"\|"show"\|"hide"` | `dynamic`   | Whether to hide planet text labels at all zoom levels |
+| `planetVisibility`      | `"dynamic"\|"show"\|"hide"` | `dynamic`   | Whether to show all planets at all zoom levels        |
+| `spacelaneVisibility`   | `"dynamic"\|"show"\|"hide"` | `dynamic`   | Whether to show all spacelanes at all zoom levels     |
+| `customOptions`         | `ReactNode`                 | `undefined` | Additional options to show in the options window      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@outoforbitdev/galaxy-map",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@outoforbitdev/galaxy-map",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "ISC",
       "dependencies": {
         "react": "^19.0.0",

--- a/src/components/GalaxyMap.tsx
+++ b/src/components/GalaxyMap.tsx
@@ -1,9 +1,10 @@
 import ZoomableMap from "./ZoomableMap";
-import { IMapOptionsProps, MapItemVisibility, MapOptions } from "./MapOptions";
+import { IMapOptionsProps, MapOptions } from "./MapOptions";
 import { ReactNode, useRef, useState } from "react";
 import { IPlanet } from "./PlanetMap";
 import { ISpacelane } from "./SpacelaneMap";
 import styles from "../styles/map.module.css";
+import { MapItemVisibility } from "./MapItemVisibilitySelect";
 
 export interface IMapProps {
   planets: IPlanet[];

--- a/src/components/GalaxyMap.tsx
+++ b/src/components/GalaxyMap.tsx
@@ -46,7 +46,7 @@ export default function Map(props: IMapProps) {
   const mapOptionsProps: IMapOptionsProps = {
     planetLabelVisibility: planetLabelVisibility,
     setPlanetLabels: setPlanetLabelVisibility,
-    planetVisilibity: planetVisibility,
+    planetVisibility: planetVisibility,
     setPlanetVisibility: setPlanetVisibility,
     spacelaneVisibility: spacelaneVisibility,
     setSpacelaneVisibility: setSpacelaneVisibility,

--- a/src/components/GalaxyMap.tsx
+++ b/src/components/GalaxyMap.tsx
@@ -1,6 +1,6 @@
 import ZoomableMap from "./ZoomableMap";
-import { IMapOptions, MapOption, MapOptions } from "./MapOptions";
-import { useRef, useState } from "react";
+import { IMapOptionsProps, MapItemVisibility, MapOptions } from "./MapOptions";
+import { ReactNode, useRef, useState } from "react";
 import { IPlanet } from "./PlanetMap";
 import { ISpacelane } from "./SpacelaneMap";
 import styles from "../styles/map.module.css";
@@ -22,89 +22,53 @@ export interface IMapProps {
   };
 }
 
+export interface IMapOptions {
+  planetLabelVisibility?: MapItemVisibility;
+  planetVisibility?: MapItemVisibility;
+  spacelaneVisibility?: MapItemVisibility;
+  customOptions?: ReactNode;
+}
+
 export default function Map(props: IMapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [hidePlanetLabels, setHidePlanetLabels] = useState(
-    props.mapOptions?.hidePlanetLabels ?? false,
+  const [planetLabelVisibility, setPlanetLabelVisibility] =
+    useState<MapItemVisibility>(
+      props.mapOptions?.planetLabelVisibility ?? "dynamic",
+    );
+  const [planetVisibility, setPlanetVisibility] = useState<MapItemVisibility>(
+    props.mapOptions?.planetVisibility ?? "dynamic",
   );
-  const [showAllPlanets, setShowAllPlanets] = useState(
-    props.mapOptions?.showAllPlanets ?? false,
-  );
-  const [showAllSpacelanes, setShowAllSpacelanes] = useState(
-    props.mapOptions?.showAllSpacelanes ?? false,
-  );
+  const [spacelaneVisibility, setSpacelaneVisibility] =
+    useState<MapItemVisibility>(
+      props.mapOptions?.spacelaneVisibility ?? "dynamic",
+    );
 
-  const mapOptions = createMapOptions(
-    hidePlanetLabels,
-    setHidePlanetLabels,
-    showAllPlanets,
-    setShowAllPlanets,
-    showAllSpacelanes,
-    setShowAllSpacelanes,
-    props.mapOptions?.customOptions || [],
-  );
+  const mapOptionsProps: IMapOptionsProps = {
+    planetLabelVisibility: planetLabelVisibility,
+    setPlanetLabels: setPlanetLabelVisibility,
+    planetVisilibity: planetVisibility,
+    setPlanetVisibility: setPlanetVisibility,
+    spacelaneVisibility: spacelaneVisibility,
+    setSpacelaneVisibility: setSpacelaneVisibility,
+  };
 
-  const mapOptionsProps: IMapOptions = {};
-  mapOptionsProps.hidePlanetLabels = hidePlanetLabels;
-  mapOptionsProps.showAllPlanets = showAllPlanets;
-  mapOptionsProps.showAllSpacelanes = showAllSpacelanes;
+  console.log(planetLabelVisibility);
 
   return (
     <div ref={containerRef} className={styles.container}>
-      <MapOptions mapOptions={mapOptions} />
+      <MapOptions {...mapOptionsProps}>
+        {props.mapOptions?.customOptions}
+      </MapOptions>
       <ZoomableMap
         containerRef={containerRef}
         {...props}
-        mapOptions={mapOptionsProps}
+        mapOptions={{
+          planetLabelsVisibility: planetLabelVisibility,
+          planetsVisibility: planetVisibility,
+          spacelanesVisiblity: spacelaneVisibility,
+        }}
         zoom={props.zoom ?? {}}
       />
     </div>
   );
-}
-
-function createMapOptions(
-  hidePlanetLabels: boolean,
-  setHidePlanetLabels: (value: boolean) => void,
-  showAllPlanets: boolean,
-  setShowAllPlanets: (value: boolean) => void,
-  showAllSpacelanes: boolean,
-  setShowAllSpacelanes: (value: boolean) => void,
-  clientMapOptions: MapOption[],
-) {
-  const defaultOptions: MapOption[] = [
-    createSingleMapOption(
-      hidePlanetLabels,
-      setHidePlanetLabels,
-      "Hide planet labels",
-      "checkbox",
-    ),
-    createSingleMapOption(
-      showAllPlanets,
-      setShowAllPlanets,
-      "Show all planets",
-      "checkbox",
-    ),
-    createSingleMapOption(
-      showAllSpacelanes,
-      setShowAllSpacelanes,
-      "Show all spacelanes",
-      "checkbox",
-    ),
-  ];
-
-  return defaultOptions.concat(clientMapOptions);
-}
-
-function createSingleMapOption<T>(
-  value: T,
-  setValue: (value: T) => void,
-  label: string,
-  inputType: string,
-) {
-  return {
-    currentValue: value,
-    setValue: setValue,
-    label: label,
-    inputType: inputType,
-  };
 }

--- a/src/components/GalaxyMap.tsx
+++ b/src/components/GalaxyMap.tsx
@@ -52,8 +52,6 @@ export default function Map(props: IMapProps) {
     setSpacelaneVisibility: setSpacelaneVisibility,
   };
 
-  console.log(planetLabelVisibility);
-
   return (
     <div ref={containerRef} className={styles.container}>
       <MapOptions {...mapOptionsProps}>

--- a/src/components/MapItemVisibilitySelect.tsx
+++ b/src/components/MapItemVisibilitySelect.tsx
@@ -1,22 +1,29 @@
 export type MapItemVisibility = "dynamic" | "show" | "hide";
 
-export function MapItemVisibilitySelect(props: {
-  label: string;
-  defaultValue: MapItemVisibility;
-  setVisibility: (value: MapItemVisibility) => void;
-}) {
+interface IMapItemVisibilitySelectProps {
+    label: string;
+    defaultValue?: MapItemVisibility;
+    value?: MapItemVisibility;
+    setVisibility: (value: MapItemVisibility) => void;
+    dynamicDisabled?: boolean;
+    showDisabled?: boolean;
+    hideDisabled?: boolean;
+  }
+
+export function MapItemVisibilitySelect(props: IMapItemVisibilitySelectProps) {
   return (
     <span>
       <label>{props.label}</label>
       <select
         defaultValue={props.defaultValue}
+        value={props.value}
         onChange={(e) =>
           props.setVisibility(GetDefaultMapItemDisplayOption(e.target.value))
         }
       >
-        <option value="dynamic">Dynamic</option>
-        <option value="show">Show</option>
-        <option value="hide">Hide</option>
+        <option value="dynamic" disabled={props.dynamicDisabled}>Dynamic</option>
+        <option value="show" disabled={props.showDisabled}>Show</option>
+        <option value="hide" disabled={props.hideDisabled}>Hide</option>
       </select>
     </span>
   );

--- a/src/components/MapItemVisibilitySelect.tsx
+++ b/src/components/MapItemVisibilitySelect.tsx
@@ -1,14 +1,14 @@
 export type MapItemVisibility = "dynamic" | "show" | "hide";
 
 interface IMapItemVisibilitySelectProps {
-    label: string;
-    defaultValue?: MapItemVisibility;
-    value?: MapItemVisibility;
-    setVisibility: (value: MapItemVisibility) => void;
-    dynamicDisabled?: boolean;
-    showDisabled?: boolean;
-    hideDisabled?: boolean;
-  }
+  label: string;
+  defaultValue?: MapItemVisibility;
+  value?: MapItemVisibility;
+  setVisibility: (value: MapItemVisibility) => void;
+  dynamicDisabled?: boolean;
+  showDisabled?: boolean;
+  hideDisabled?: boolean;
+}
 
 export function MapItemVisibilitySelect(props: IMapItemVisibilitySelectProps) {
   return (
@@ -21,9 +21,15 @@ export function MapItemVisibilitySelect(props: IMapItemVisibilitySelectProps) {
           props.setVisibility(GetDefaultMapItemDisplayOption(e.target.value))
         }
       >
-        <option value="dynamic" disabled={props.dynamicDisabled}>Dynamic</option>
-        <option value="show" disabled={props.showDisabled}>Show</option>
-        <option value="hide" disabled={props.hideDisabled}>Hide</option>
+        <option value="dynamic" disabled={props.dynamicDisabled}>
+          Dynamic
+        </option>
+        <option value="show" disabled={props.showDisabled}>
+          Show
+        </option>
+        <option value="hide" disabled={props.hideDisabled}>
+          Hide
+        </option>
       </select>
     </span>
   );

--- a/src/components/MapItemVisibilitySelect.tsx
+++ b/src/components/MapItemVisibilitySelect.tsx
@@ -1,0 +1,36 @@
+export type MapItemVisibility = "dynamic" | "show" | "hide";
+
+export function MapItemVisibilitySelect(props: {
+  label: string;
+  defaultValue: MapItemVisibility;
+  setVisibility: (value: MapItemVisibility) => void;
+}) {
+  return (
+    <span>
+      <label>{props.label}</label>
+      <select
+        defaultValue={props.defaultValue}
+        onChange={(e) =>
+          props.setVisibility(GetDefaultMapItemDisplayOption(e.target.value))
+        }
+      >
+        <option value="dynamic">Dynamic</option>
+        <option value="show">Show</option>
+        <option value="hide">Hide</option>
+      </select>
+    </span>
+  );
+}
+
+function GetDefaultMapItemDisplayOption(value: string): MapItemVisibility {
+  switch (value) {
+    case "dynamic":
+      return value;
+    case "show":
+      return value;
+    case "hide":
+      return value;
+    default:
+      return "dynamic";
+  }
+}

--- a/src/components/MapOptions.tsx
+++ b/src/components/MapOptions.tsx
@@ -1,41 +1,74 @@
 import { Expandable } from "../oodreact";
+import { IComponentProps } from "../oodreact/IComponent";
 import styles from "../styles/map.module.css";
 
-export interface IMapOptions {
-  hidePlanetLabels?: boolean;
-  showAllPlanets?: boolean;
-  showAllSpacelanes?: boolean;
-  customOptions?: MapOption[];
+export type MapItemVisibility = "dynamic" | "show" | "hide";
+
+export interface IMapOptionsProps extends IComponentProps {
+  planetLabelVisibility: MapItemVisibility;
+  setPlanetLabels: (value: MapItemVisibility) => void;
+  planetVisilibity: MapItemVisibility;
+  setPlanetVisibility: (value: MapItemVisibility) => void;
+  spacelaneVisibility: MapItemVisibility;
+  setSpacelaneVisibility: (value: MapItemVisibility) => void;
 }
 
-interface IMapOption<T> {
-  currentValue: T;
-  setValue: (value: T) => void;
-  label: string;
-  inputType: string;
-}
-
-export type MapOption = IMapOption<boolean>;
-
-interface IMapOptionProps {
-  mapOptions: MapOption[];
-}
-
-export function MapOptions(props: IMapOptionProps) {
+export function MapOptions(props: IMapOptionsProps) {
   return (
     <Expandable className={styles.optionsWindow} title="Map Options">
       <div className={styles.optionsWindowContent}>
-        {props.mapOptions.map((p, i) => (
-          <span key={i}>
-            <input
-              type={p.inputType}
-              onChange={(event) => p.setValue(event.target.checked)}
-              checked={p.currentValue}
-            />
-            <label>{p.label}</label>
-          </span>
-        ))}
+        <MapItemVisibilitySelect
+          label="Planet Labels"
+          defaultValue={props.planetLabelVisibility}
+          setVisibility={props.setPlanetLabels}
+        />
+        <MapItemVisibilitySelect
+          label="Planets"
+          defaultValue={props.planetVisilibity}
+          setVisibility={props.setPlanetVisibility}
+        />
+        <MapItemVisibilitySelect
+          label="Spacelanes"
+          defaultValue={props.spacelaneVisibility}
+          setVisibility={props.setSpacelaneVisibility}
+        />
+        {props.children}
       </div>
     </Expandable>
   );
+}
+
+function MapItemVisibilitySelect(props: {
+  label: string;
+  defaultValue: MapItemVisibility;
+  setVisibility: (value: MapItemVisibility) => void;
+}) {
+  return (
+    <span>
+      <label>{props.label}</label>
+      <select
+        defaultValue={props.defaultValue}
+        onChange={(e) =>
+          props.setVisibility(GetDefaultMapItemDisplayOption(e.target.value))
+        }
+      >
+        <option value="dynamic">Dynamic</option>
+        <option value="show">Show</option>
+        <option value="hide">Hide</option>
+      </select>
+    </span>
+  );
+}
+
+function GetDefaultMapItemDisplayOption(value: string): MapItemVisibility {
+  switch (value) {
+    case "dynamic":
+      return value;
+    case "show":
+      return value;
+    case "hide":
+      return value;
+    default:
+      return "dynamic";
+  }
 }

--- a/src/components/MapOptions.tsx
+++ b/src/components/MapOptions.tsx
@@ -16,18 +16,26 @@ export interface IMapOptionsProps extends IComponentProps {
 }
 
 export function MapOptions(props: IMapOptionsProps) {
+  const setPlanetVisiblityAndLabelVisibility = function (planetVisibility: MapItemVisibility) {
+    props.setPlanetVisibility(planetVisibility);
+    if (planetVisibility === "hide") {
+      props.setPlanetLabels("hide");
+    }
+  }
   return (
     <Expandable className={styles.optionsWindow} title="Map Options">
       <div className={styles.optionsWindowContent}>
         <MapItemVisibilitySelect
           label="Planet Labels"
-          defaultValue={props.planetLabelVisibility}
+          value={props.planetLabelVisibility}
           setVisibility={props.setPlanetLabels}
+          dynamicDisabled={props.planetVisibility === "hide"}
+          showDisabled={props.planetVisibility === "hide"}
         />
         <MapItemVisibilitySelect
           label="Planets"
           defaultValue={props.planetVisibility}
-          setVisibility={props.setPlanetVisibility}
+          setVisibility={setPlanetVisiblityAndLabelVisibility}
         />
         <MapItemVisibilitySelect
           label="Spacelanes"

--- a/src/components/MapOptions.tsx
+++ b/src/components/MapOptions.tsx
@@ -7,7 +7,7 @@ export type MapItemVisibility = "dynamic" | "show" | "hide";
 export interface IMapOptionsProps extends IComponentProps {
   planetLabelVisibility: MapItemVisibility;
   setPlanetLabels: (value: MapItemVisibility) => void;
-  planetVisilibity: MapItemVisibility;
+  planetVisibility: MapItemVisibility;
   setPlanetVisibility: (value: MapItemVisibility) => void;
   spacelaneVisibility: MapItemVisibility;
   setSpacelaneVisibility: (value: MapItemVisibility) => void;
@@ -24,7 +24,7 @@ export function MapOptions(props: IMapOptionsProps) {
         />
         <MapItemVisibilitySelect
           label="Planets"
-          defaultValue={props.planetVisilibity}
+          defaultValue={props.planetVisibility}
           setVisibility={props.setPlanetVisibility}
         />
         <MapItemVisibilitySelect

--- a/src/components/MapOptions.tsx
+++ b/src/components/MapOptions.tsx
@@ -16,12 +16,14 @@ export interface IMapOptionsProps extends IComponentProps {
 }
 
 export function MapOptions(props: IMapOptionsProps) {
-  const setPlanetVisiblityAndLabelVisibility = function (planetVisibility: MapItemVisibility) {
+  const setPlanetVisiblityAndLabelVisibility = function (
+    planetVisibility: MapItemVisibility,
+  ) {
     props.setPlanetVisibility(planetVisibility);
     if (planetVisibility === "hide") {
       props.setPlanetLabels("hide");
     }
-  }
+  };
   return (
     <Expandable className={styles.optionsWindow} title="Map Options">
       <div className={styles.optionsWindowContent}>

--- a/src/components/MapOptions.tsx
+++ b/src/components/MapOptions.tsx
@@ -1,8 +1,10 @@
 import { Expandable } from "../oodreact";
 import { IComponentProps } from "../oodreact/IComponent";
+import {
+  MapItemVisibility,
+  MapItemVisibilitySelect,
+} from "./MapItemVisibilitySelect";
 import styles from "../styles/map.module.css";
-
-export type MapItemVisibility = "dynamic" | "show" | "hide";
 
 export interface IMapOptionsProps extends IComponentProps {
   planetLabelVisibility: MapItemVisibility;
@@ -36,39 +38,4 @@ export function MapOptions(props: IMapOptionsProps) {
       </div>
     </Expandable>
   );
-}
-
-function MapItemVisibilitySelect(props: {
-  label: string;
-  defaultValue: MapItemVisibility;
-  setVisibility: (value: MapItemVisibility) => void;
-}) {
-  return (
-    <span>
-      <label>{props.label}</label>
-      <select
-        defaultValue={props.defaultValue}
-        onChange={(e) =>
-          props.setVisibility(GetDefaultMapItemDisplayOption(e.target.value))
-        }
-      >
-        <option value="dynamic">Dynamic</option>
-        <option value="show">Show</option>
-        <option value="hide">Hide</option>
-      </select>
-    </span>
-  );
-}
-
-function GetDefaultMapItemDisplayOption(value: string): MapItemVisibility {
-  switch (value) {
-    case "dynamic":
-      return value;
-    case "show":
-      return value;
-    case "hide":
-      return value;
-    default:
-      return "dynamic";
-  }
 }

--- a/src/components/Zoomable.tsx
+++ b/src/components/Zoomable.tsx
@@ -175,6 +175,5 @@ function calculateNewTotalOffset(
     x: (oldTotalOffset.x / oldZoomModifier) * newZoomModifier,
     y: (oldTotalOffset.y / oldZoomModifier) * newZoomModifier,
   };
-  // console.log(`oldMouseX: ${oldTotalOffset.x}, newMouseX: ${newTotalOffset.x}, oldZoom: ${oldZoomModifier}, newZoom: ${newZoomModifier}`);
   return newTotalOffset;
 }

--- a/src/components/ZoomableMap.tsx
+++ b/src/components/ZoomableMap.tsx
@@ -100,9 +100,6 @@ function zoomLevelToClassNames(
   zoomLevel: number,
   zoomModifier: number,
 ): string {
-  console.log(
-    `zoomLevel: ${zoomLevel}, modifiedZoom: ${zoomLevel * zoomModifier}`,
-  );
   return (
     getZoomStyle(zoomLevel) + " " + getHiddenStyles(zoomLevel * zoomModifier)
   );

--- a/src/components/ZoomableMap.tsx
+++ b/src/components/ZoomableMap.tsx
@@ -5,7 +5,7 @@ import { Draggable } from "../oodreact";
 import Zoomable from "./Zoomable";
 import styles from "../styles/items.module.css";
 import { getDomProps } from "../oodreact/IComponent";
-import { MapItemVisibility } from "./MapOptions";
+import { MapItemVisibility } from "./MapItemVisibilitySelect";
 
 export interface IZoomableMapProps {
   planets: IPlanet[];
@@ -183,15 +183,13 @@ function getMapLabelVisibilityStyle(
   visibility: MapItemVisibility,
   itemVisibility: MapItemVisibility,
 ): string {
-  if (itemVisibility === "hide" || visibility === "hide") {
-    return itemType === "planet_label"
-      ? styles.hide_planet_labels
-      : styles.hide_spacelane_labels;
-  } else if (visibility === "dynamic") {
-    return "";
-  } else {
-    return itemType === "planet_label"
-      ? styles.show_planet_labels
-      : styles.show_spacelane_labels;
+  switch (visibility) {
+    case "show":
+      return styles.show_planet_labels
+    case "hide":
+      return styles.hide_planet_labels
+    case "dynamic":
+    default:
+      return "";
   }
 }

--- a/src/components/ZoomableMap.tsx
+++ b/src/components/ZoomableMap.tsx
@@ -1,11 +1,11 @@
 import { RefObject, useState } from "react";
 import PlanetMap, { IPlanet } from "./PlanetMap";
 import SpacelaneMap, { ISpacelane } from "./SpacelaneMap";
-import { IMapOptions } from "./MapOptions";
 import { Draggable } from "../oodreact";
 import Zoomable from "./Zoomable";
 import styles from "../styles/items.module.css";
 import { getDomProps } from "../oodreact/IComponent";
+import { MapItemVisibility } from "./MapOptions";
 
 export interface IZoomableMapProps {
   planets: IPlanet[];
@@ -23,6 +23,12 @@ export interface IZoomableMapProps {
     min?: number;
     max?: number;
   };
+}
+
+interface IMapOptions {
+  planetLabelsVisibility: MapItemVisibility;
+  planetsVisibility: MapItemVisibility;
+  spacelanesVisiblity: MapItemVisibility;
 }
 
 export default function ZoomableMap(props: IZoomableMapProps) {
@@ -52,9 +58,19 @@ export default function ZoomableMap(props: IZoomableMapProps) {
         {...getDomProps(
           {},
           zoomClassName,
-          props.mapOptions.hidePlanetLabels ? styles.hide_planet_labels : "",
-          props.mapOptions.showAllPlanets ? styles.show_planets : "",
-          props.mapOptions.showAllSpacelanes ? styles.show_spacelanes : "",
+          getMapLabelVisibilityStyle(
+            "planet_label",
+            props.mapOptions.planetLabelsVisibility,
+            props.mapOptions.planetsVisibility,
+          ),
+          getMapItemVisilibityStyle(
+            "planet",
+            props.mapOptions.planetsVisibility,
+          ),
+          getMapItemVisilibityStyle(
+            "spacelane",
+            props.mapOptions.spacelanesVisiblity,
+          ),
         )}
       >
         {props.spacelanes.map((s: ISpacelane, _i: number) => (
@@ -144,4 +160,41 @@ function getHiddenStyles(zoomLevel: number): string {
   }
 
   return hiddenStyles;
+}
+
+function getMapItemVisilibityStyle(
+  itemType: "planet" | "spacelane",
+  visibility: MapItemVisibility,
+): string {
+  switch (visibility) {
+    case "show":
+      return itemType === "planet"
+        ? styles.show_planets
+        : styles.show_spacelanes;
+    case "hide":
+      return itemType === "planet"
+        ? styles.hide_planets
+        : styles.hide_spacelanes;
+    case "dynamic":
+    default:
+      return "";
+  }
+}
+
+function getMapLabelVisibilityStyle(
+  itemType: "planet_label" | "spacelane_label",
+  visibility: MapItemVisibility,
+  itemVisibility: MapItemVisibility,
+): string {
+  if (itemVisibility === "hide" || visibility === "hide") {
+    return itemType === "planet_label"
+      ? styles.hide_planet_labels
+      : styles.hide_spacelane_labels;
+  } else if (visibility === "dynamic") {
+    return "";
+  } else {
+    return itemType === "planet_label"
+      ? styles.show_planet_labels
+      : styles.show_spacelane_labels;
+  }
 }

--- a/src/components/ZoomableMap.tsx
+++ b/src/components/ZoomableMap.tsx
@@ -185,9 +185,9 @@ function getMapLabelVisibilityStyle(
 ): string {
   switch (visibility) {
     case "show":
-      return styles.show_planet_labels
+      return styles.show_planet_labels;
     case "hide":
-      return styles.hide_planet_labels
+      return styles.hide_planet_labels;
     case "dynamic":
     default:
       return "";

--- a/src/oodreact/Expandable.tsx
+++ b/src/oodreact/Expandable.tsx
@@ -13,6 +13,9 @@ export function Expandable(props: IExpandableProps) {
     <div {...getDomProps(props, styles.expandable)}>
       {expanded ? (
         <span>
+          {expanded && props.title ? (
+            <span className={styles.title}>{props.title}</span>
+          ) : null}
           <DoubleArrowUp
             onClick={() => setExpanded(false)}
             className={styles.toggle}

--- a/src/oodreact/expandable.module.css
+++ b/src/oodreact/expandable.module.css
@@ -4,6 +4,10 @@
   border-radius: 5px;
 }
 
+.title {
+  padding: 0.5rem;
+}
+
 .toggle {
   float: right;
 }

--- a/src/styles/items.module.css
+++ b/src/styles/items.module.css
@@ -92,8 +92,11 @@
 }
 
 .hide_quaternary .quaternary .map_item {
-  font-size: 0;
   stroke-width: 0;
+}
+
+.hide_quaternary .quaternary text.map_label {
+  font-size: 0;
 }
 
 .hide_tertiary_label .tertiary .map_label {
@@ -101,8 +104,11 @@
 }
 
 .hide_tertiary .tertiary .map_item {
-  font-size: 0;
   stroke-width: 0;
+}
+
+.hide_tertiary .tertiary text.map_label {
+  font-size: 0;
 }
 
 .hide_secondary_label .secondary .map_label {
@@ -110,16 +116,18 @@
 }
 
 .hide_secondary .secondary .map_item {
-  font-size: 0;
   stroke-width: 0;
 }
 
-.hide_planets .planet {
-  stroke-width: 0;
+.hide_secondary .secondary text.map_label {
   font-size: 0;
 }
 
-.hide_planet_labels .planet .map_label {
+.hide_planets .planet .map_item {
+  stroke-width: 0;
+}
+
+.hide_planet_labels .planet text.map_label {
   font-size: 0;
 }
 
@@ -128,7 +136,15 @@
   stroke-width: calc(0.5 * (var(--size-modifier) * var(--text-size)));
 }
 
-.hide_spacelanes .spacelane {
+.show_planets.show_planet_labels .planet .map_label {
+  font-size: calc(var(--size-modifier) * var(--text-size));
+}
+
+.show_planet_labels .planet .map_label {
+  font-size: calc(var(--size-modifier) * var(--text-size));
+}
+
+.hide_spacelanes .spacelane .map_item {
   stroke-width: 0;
   font-size: 0;
 }

--- a/src/styles/map.module.css
+++ b/src/styles/map.module.css
@@ -25,3 +25,8 @@ div.container {
   display: flex;
   flex-direction: column;
 }
+
+.optionsWindowContent select {
+  float: right;
+  margin-left: 1rem;
+}


### PR DESCRIPTION
## Summary

This pull request changes the way the Map Options window functions
- The default options (`hidePlanetLabels`, `showPlanets`, and `showSpacelanes`) have been renamed to `planetLabelVisibility`, `planetVisibility`, and `spacelaneVisbility`, and accept any of the following strings: `show`, `dynamic` (default), or `hide` instead of `booleans`.
  - These options are now rendered as dropdown menus in the options window instead of boolean checkboxes.
- Instead of providing complex objects for `customOptions`, consumers now provide a `ReactNode`.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

Tested in `app-galaxy-map` with `just pack`.

## Issues

Closes #43
