### PR TITLE
fix: correct zoom direction on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Next
+
+### Breaking Changes
+
+- The zoom direction for scrolling has been reversed to match Google Maps:
+  - On Windows scrolling up zooms in and scrolling down zooms out
+  - On MacOS scrolling up zooms out and scrolling down zooms in
+
 ## 0.0.8 (2025-04-05)
 
 ### Breaking Changes

--- a/src/components/Zoomable.tsx
+++ b/src/components/Zoomable.tsx
@@ -96,7 +96,7 @@ export default function Zoomable(props: IZoomableProps) {
   };
 
   const onWheel: WheelEventHandler<SVGElement> = function (e) {
-    adjustZoom(e.deltaY * 0.01, e);
+    adjustZoom(e.deltaY * -0.01, e);
   };
 
   const onClick = function (e: React.MouseEvent<SVGElement, MouseEvent>) {


### PR DESCRIPTION
## Summary

The zoom direction for scrolling has been reversed to match Google Maps:
- On Windows scrolling up zooms in and scrolling down zooms out
- On MacOS scrolling up zooms out and scrolling down zooms in

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

- Tested using `just pack`

## Issues

Closes #62
