### PR TITLE
feat: implement coordinate utilities

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,4 @@
+- Common commands for this repo are defined in Justfile
+- The lint command is just lint
+- Packages are managed with npm, not yarn.
+- There is a PR template for this repo, look at previous PRs to see examples.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+@../.agents/AGENTS.md

--- a/src/__tests__/trivial.test.ts
+++ b/src/__tests__/trivial.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("trivial", () => {
-  it("passes", () => {
-    expect(1 + 1).toBe(2);
-  });
-});

--- a/src/utils/coordinates.ts
+++ b/src/utils/coordinates.ts
@@ -1,2 +1,95 @@
-// TODO: implement screen↔map conversion, mapCenter, computeViewport
-export {};
+import { IMapCoordinate, IMapDimensions } from "../types";
+
+/**
+ * The visible region of the map in map coordinates.
+ * Y increases upward (mathematical convention), so minY is the bottom of the
+ * screen and maxY is the top.
+ */
+export interface IViewport {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/**
+ * Returns the midpoint of the given map dimensions.
+ *
+ * Used as the default `center` when no `initialCenter` is provided.
+ */
+export function mapCenter(dimensions: IMapDimensions): IMapCoordinate {
+  return {
+    x: (dimensions.min.x + dimensions.max.x) / 2,
+    y: (dimensions.min.y + dimensions.max.y) / 2,
+  };
+}
+
+/**
+ * Computes the visible region in map coordinates for the given center, zoom
+ * level, and container dimensions.
+ *
+ * Because map coordinates use an upward Y axis, minY corresponds to the bottom
+ * of the screen and maxY to the top.
+ */
+export function computeViewport(
+  center: IMapCoordinate,
+  zoom: number,
+  containerWidth: number,
+  containerHeight: number,
+): IViewport {
+  const halfW = containerWidth / 2 / zoom;
+  const halfH = containerHeight / 2 / zoom;
+  return {
+    minX: center.x - halfW,
+    maxX: center.x + halfW,
+    minY: center.y - halfH,
+    maxY: center.y + halfH,
+  };
+}
+
+/**
+ * Converts a map coordinate `(mapX, mapY)` to a screen (SVG pixel) coordinate.
+ *
+ * The forward transform accounts for the inverted Y axis:
+ *   sx =  zoom * (mapX - center.x) + svgWidth  / 2
+ *   sy = -zoom * (mapY - center.y) + svgHeight / 2
+ *
+ * Used by `PlanetLabelLayer` to position labels in screen space.
+ */
+export function mapToScreen(
+  mapX: number,
+  mapY: number,
+  center: IMapCoordinate,
+  zoom: number,
+  svgWidth: number,
+  svgHeight: number,
+): { x: number; y: number } {
+  return {
+    x: zoom * (mapX - center.x) + svgWidth / 2,
+    y: -zoom * (mapY - center.y) + svgHeight / 2,
+  };
+}
+
+/**
+ * Converts a screen (SVG pixel) coordinate `(screenX, screenY)` to a map
+ * coordinate.
+ *
+ * The inverse transform accounts for the inverted Y axis:
+ *   mapX = center.x + (screenX - svgWidth  / 2) / zoom
+ *   mapY = center.y - (screenY - svgHeight / 2) / zoom
+ *
+ * Used for zoom-to-cursor and click hit-testing.
+ */
+export function screenToMap(
+  screenX: number,
+  screenY: number,
+  center: IMapCoordinate,
+  zoom: number,
+  svgWidth: number,
+  svgHeight: number,
+): IMapCoordinate {
+  return {
+    x: center.x + (screenX - svgWidth / 2) / zoom,
+    y: center.y - (screenY - svgHeight / 2) / zoom,
+  };
+}

--- a/tests/coordinates.test.ts
+++ b/tests/coordinates.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapCenter,
+  computeViewport,
+  mapToScreen,
+  screenToMap,
+} from "../src/utils/coordinates";
+
+describe("mapCenter", () => {
+  it("returns the midpoint of symmetric dimensions", () => {
+    const center = mapCenter({
+      min: { x: -100, y: -100 },
+      max: { x: 100, y: 100 },
+    });
+    expect(center).toEqual({ x: 0, y: 0 });
+  });
+
+  it("returns the midpoint of asymmetric dimensions", () => {
+    const center = mapCenter({
+      min: { x: 0, y: 200 },
+      max: { x: 400, y: 600 },
+    });
+    expect(center).toEqual({ x: 200, y: 400 });
+  });
+
+  it("handles negative-only ranges", () => {
+    const center = mapCenter({
+      min: { x: -800, y: -600 },
+      max: { x: -200, y: -100 },
+    });
+    expect(center).toEqual({ x: -500, y: -350 });
+  });
+});
+
+describe("computeViewport", () => {
+  it("spans the full container at zoom=1", () => {
+    const vp = computeViewport({ x: 0, y: 0 }, 1, 800, 600);
+    expect(vp.minX).toBe(-400);
+    expect(vp.maxX).toBe(400);
+    expect(vp.minY).toBe(-300);
+    expect(vp.maxY).toBe(300);
+  });
+
+  it("halves the visible range at zoom=2", () => {
+    const vp = computeViewport({ x: 0, y: 0 }, 2, 800, 600);
+    expect(vp.minX).toBe(-200);
+    expect(vp.maxX).toBe(200);
+    expect(vp.minY).toBe(-150);
+    expect(vp.maxY).toBe(150);
+  });
+
+  it("offsets the viewport by center position", () => {
+    const vp = computeViewport({ x: 500, y: 300 }, 1, 200, 100);
+    expect(vp.minX).toBe(400);
+    expect(vp.maxX).toBe(600);
+    expect(vp.minY).toBe(250);
+    expect(vp.maxY).toBe(350);
+  });
+});
+
+describe("mapToScreen / screenToMap round-trip", () => {
+  const cases: Array<{
+    label: string;
+    mapX: number;
+    mapY: number;
+    center: { x: number; y: number };
+    zoom: number;
+    svgWidth: number;
+    svgHeight: number;
+  }> = [
+    {
+      label: "origin at zoom=1, centered at origin",
+      mapX: 0,
+      mapY: 0,
+      center: { x: 0, y: 0 },
+      zoom: 1,
+      svgWidth: 800,
+      svgHeight: 600,
+    },
+    {
+      label: "off-center point at zoom=2",
+      mapX: 150,
+      mapY: -75,
+      center: { x: 100, y: -50 },
+      zoom: 2,
+      svgWidth: 1024,
+      svgHeight: 768,
+    },
+    {
+      label: "large coordinates at fractional zoom",
+      mapX: 3000,
+      mapY: 1500,
+      center: { x: 2500, y: 1000 },
+      zoom: 0.5,
+      svgWidth: 400,
+      svgHeight: 300,
+    },
+  ];
+
+  for (const {
+    label,
+    mapX,
+    mapY,
+    center,
+    zoom,
+    svgWidth,
+    svgHeight,
+  } of cases) {
+    it(`round-trips correctly: ${label}`, () => {
+      const screen = mapToScreen(mapX, mapY, center, zoom, svgWidth, svgHeight);
+      const result = screenToMap(
+        screen.x,
+        screen.y,
+        center,
+        zoom,
+        svgWidth,
+        svgHeight,
+      );
+      expect(result.x).toBeCloseTo(mapX, 10);
+      expect(result.y).toBeCloseTo(mapY, 10);
+    });
+  }
+
+  it("places the center coordinate at the screen center", () => {
+    const center = { x: 200, y: 300 };
+    const screen = mapToScreen(center.x, center.y, center, 2, 800, 600);
+    expect(screen.x).toBeCloseTo(400, 10);
+    expect(screen.y).toBeCloseTo(300, 10);
+  });
+
+  it("screenToMap of screen center returns map center", () => {
+    const center = { x: 200, y: 300 };
+    const result = screenToMap(400, 300, center, 2, 800, 600);
+    expect(result.x).toBeCloseTo(200, 10);
+    expect(result.y).toBeCloseTo(300, 10);
+  });
+
+  it("Y axis is inverted: positive mapY maps to screen y < svgHeight/2", () => {
+    // A point above center in map space should appear above the screen midpoint
+    // (lower screen Y value because SVG Y increases downward).
+    const center = { x: 0, y: 0 };
+    const screen = mapToScreen(0, 100, center, 1, 800, 600);
+    expect(screen.y).toBeLessThan(300);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the coordinate utility functions in `src/utils/coordinates.ts` as specified in issue #98:

- `mapCenter(dimensions)` — returns the midpoint of `IMapDimensions`
- `computeViewport(center, zoom, containerWidth, containerHeight)` — returns the visible map region as `IViewport`
- `mapToScreen(mapX, mapY, center, zoom, svgWidth, svgHeight)` — converts a map coordinate to a screen (SVG pixel) coordinate
- `screenToMap(screenX, screenY, center, zoom, svgWidth, svgHeight)` — converts a screen coordinate back to a map coordinate

All four functions account for the inverted Y axis (map coordinates use an upward Y axis; SVG uses a downward Y axis). `IViewport` is defined and exported locally from `coordinates.ts`.

Also removes the trivial placeholder test and adds a real test suite at `tests/coordinates.test.ts` covering: `mapCenter` with symmetric/asymmetric/negative ranges; `computeViewport` at multiple zoom levels; and round-trip `mapToScreen` → `screenToMap` conversion.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

All 12 unit tests pass (`npm test`). Linting passes (`just lint`).

## Issues

Closes #98